### PR TITLE
Introducing the_post_navigation and edit_post_link in single.php

### DIFF
--- a/single.php
+++ b/single.php
@@ -27,11 +27,13 @@ get_header(); ?>
 		?>
 
 		<?php the_content(); ?>
+		<?php edit_post_link( __( 'Edit', 'foundationpress' ), '<span class="edit-link">', '</span>' ); ?>
 		</div>
 		<footer>
 			<?php wp_link_pages( array('before' => '<nav id="page-nav"><p>' . __( 'Pages:', 'foundationpress' ), 'after' => '</p></nav>' ) ); ?>
 			<p><?php the_tags(); ?></p>
 		</footer>
+		<?php the_post_navigation();?>
 		<?php do_action( 'foundationpress_post_before_comments' ); ?>
 		<?php comments_template(); ?>
 		<?php do_action( 'foundationpress_post_after_comments' ); ?>


### PR DESCRIPTION
the_post_navigation since WP 4.1: https://developer.wordpress.org/reference/functions/the_post_navigation/
edit_post_link for users not displaying WP Toolbar